### PR TITLE
Doc store dev

### DIFF
--- a/document/document.go
+++ b/document/document.go
@@ -1,0 +1,39 @@
+package document
+
+import (
+	"fmt"
+)
+
+type Document struct {
+	ID       string        `json:"_id"`
+	SlotID   uint32        `json:"_slot"`
+	Fields   []Field       `json:"fields"`
+	Version  uint64        `json:"_version"`
+	Source   []byte        `json:"_source"`
+}
+
+func NewDocument(id string, slotID uint32, version uint64, source []byte) *Document {
+	return &Document{
+		ID:              id,
+		SlotID:          slotID,
+		Version:         version,
+		Fields:          make([]Field, 0),
+		Source:          source,
+	}
+}
+
+func (d *Document) AddField(f Field) *Document {
+	d.Fields = append(d.Fields, f)
+	return d
+}
+
+func (d *Document) String() string {
+	fields := ""
+	for i, field := range d.Fields {
+		if i != 0 {
+			fields += ", "
+		}
+		fields += fmt.Sprintf("%#v", field)
+	}
+	return fmt.Sprintf("&document.Document{ID:%s, Fields: %s, Source: %s}", d.ID, fields, string(d.Source))
+}

--- a/document/field.go
+++ b/document/field.go
@@ -1,0 +1,32 @@
+package document
+
+type FieldType int
+
+const (
+	String FieldType = iota
+	Number
+	Boolean
+	Date
+)
+
+type Field interface {
+	// Name returns the path of the field from the root DocumentMapping.
+	// A root field path is "field", a sub document field is "parent.field".
+	// for example,
+	// struct {
+	//     name   string
+	//     parent  struct {
+	//         field1   string
+	//         field2   string
+	//     }
+	// }
+	// the name of field1 is parent.field1
+	Name() string
+
+	Value() []byte
+
+	// NumPlainTextBytes should return the number of plain text bytes
+	// that this field represents - this is a common metric for tracking
+	// the rate of indexing
+	NumPlainTextBytes() uint64
+}

--- a/document/field_boolean.go
+++ b/document/field_boolean.go
@@ -1,0 +1,56 @@
+package document
+
+import (
+	"fmt"
+)
+
+type BooleanField struct {
+	name              string
+	value             []byte
+	numPlainTextBytes uint64
+}
+
+func (b *BooleanField) Name() string {
+	return b.name
+}
+
+func (b *BooleanField) Value() []byte {
+	return b.value
+}
+
+func (b *BooleanField) Boolean() (bool, error) {
+	if len(b.value) == 1 {
+		return b.value[0] == 'T', nil
+	}
+	return false, fmt.Errorf("boolean field has %d bytes", len(b.value))
+}
+
+func (b *BooleanField) String() string {
+	return fmt.Sprintf("&document.BooleanField{Name:%s, Value: %s}", b.name, b.value)
+}
+
+func (b *BooleanField) NumPlainTextBytes() uint64 {
+	return b.numPlainTextBytes
+}
+
+func NewBooleanFieldFromBytes(name string, value []byte) *BooleanField {
+	return &BooleanField{
+		name:              name,
+		value:             value,
+		numPlainTextBytes: uint64(len(value)),
+	}
+}
+
+func NewBooleanField(name string, b bool) *BooleanField {
+	numPlainTextBytes := 5
+	v := []byte("F")
+	if b {
+		numPlainTextBytes = 4
+		v = []byte("T")
+	}
+	return &BooleanField{
+		name:              name,
+		value:             v,
+		numPlainTextBytes: uint64(numPlainTextBytes),
+	}
+}

--- a/document/field_datetime.go
+++ b/document/field_datetime.go
@@ -1,0 +1,71 @@
+package document
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/tiglabs/baud/document/numeric"
+)
+
+var MinTimeRepresentable = time.Unix(0, math.MinInt64)
+var MaxTimeRepresentable = time.Unix(0, math.MaxInt64)
+
+type DateTimeField struct {
+	name              string
+	arrayPositions    []uint64
+	value             numeric.PrefixCoded
+	numPlainTextBytes uint64
+}
+
+func (n *DateTimeField) Name() string {
+	return n.name
+}
+
+func (n *DateTimeField) Value() []byte {
+	return n.value
+}
+
+func (n *DateTimeField) DateTime() (time.Time, error) {
+	i64, err := n.value.Int64()
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(0, i64).UTC(), nil
+}
+
+func (n *DateTimeField) String() string {
+	return fmt.Sprintf("&document.DateField{Name:%s, Value: %s}", n.name, n.value)
+}
+
+func (n *DateTimeField) NumPlainTextBytes() uint64 {
+	return n.numPlainTextBytes
+}
+
+func NewDateTimeFieldFromBytes(name string, value []byte) *DateTimeField {
+	return &DateTimeField{
+		name:              name,
+		value:             value,
+		numPlainTextBytes: uint64(len(value)),
+	}
+}
+
+func NewDateTimeField(name string, dt time.Time) (*DateTimeField, error) {
+	if validTime(dt) {
+		dtInt64 := dt.UnixNano()
+		prefixCoded := numeric.MustNewPrefixCodedInt64(dtInt64, 0)
+		return &DateTimeField{
+			name:           name,
+			value:          prefixCoded,
+			numPlainTextBytes: uint64(8),
+		}, nil
+	}
+	return nil, fmt.Errorf("cannot represent %s in this type", dt)
+}
+
+func validTime(dt time.Time) bool {
+	if dt.Before(MinTimeRepresentable) || dt.After(MaxTimeRepresentable) {
+		return false
+	}
+	return true
+}

--- a/document/field_numeric.go
+++ b/document/field_numeric.go
@@ -1,0 +1,60 @@
+package document
+
+import (
+	"fmt"
+
+	"github.com/tiglabs/baud/document/numeric"
+)
+
+/*
+数值类型，注意numeric并不是一个类型，它包括多种类型，比如：long,integer,short,byte,double,float，
+每种的存储空间都是不一样的，一般默认推荐integer和float。
+详细参考elasticsearch官方文档 https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html
+*/
+type NumericField struct {
+	name              string
+	value             numeric.PrefixCoded
+	numPlainTextBytes uint64
+}
+
+func (n *NumericField) Name() string {
+	return n.name
+}
+
+func (n *NumericField) Value() []byte {
+	return n.value
+}
+
+func (n *NumericField) Number() (float64, error) {
+	i64, err := n.value.Int64()
+	if err != nil {
+		return 0.0, err
+	}
+	return numeric.Int64ToFloat64(i64), nil
+}
+
+func (n *NumericField) String() string {
+	return fmt.Sprintf("&document.NumericField{Name:%s, Value: %s}", n.name, n.value)
+}
+
+func (n *NumericField) NumPlainTextBytes() uint64 {
+	return n.numPlainTextBytes
+}
+
+func NewNumericFieldFromBytes(name string, value []byte) *NumericField {
+	return &NumericField{
+		name:              name,
+		value:             value,
+		numPlainTextBytes: uint64(len(value)),
+	}
+}
+
+func NewNumericField(name string, number float64) *NumericField {
+	numberInt64 := numeric.Float64ToInt64(number)
+	prefixCoded := numeric.MustNewPrefixCodedInt64(numberInt64, 0)
+	return &NumericField{
+		name:           name,
+		value:          prefixCoded,
+		numPlainTextBytes: uint64(8),
+	}
+}

--- a/document/field_text.go
+++ b/document/field_text.go
@@ -1,0 +1,36 @@
+package document
+
+import (
+	"fmt"
+)
+
+type TextField struct {
+	name              string
+	value             []byte
+	numPlainTextBytes uint64
+}
+
+func (t *TextField) Name() string {
+	return t.name
+}
+
+func (t *TextField) Value() []byte {
+	return t.value
+}
+
+func (t *TextField) String() string {
+	return fmt.Sprintf("&document.TextField{Name:%s, Value: %s}", t.name, t.value)
+}
+
+func (t *TextField) NumPlainTextBytes() uint64 {
+	return t.numPlainTextBytes
+}
+
+func NewTextField(name string, value []byte) *TextField {
+	return &TextField{
+		name:              name,
+		value:             value,
+		numPlainTextBytes: uint64(len(value)),
+	}
+}
+

--- a/document/numeric/bin.go
+++ b/document/numeric/bin.go
@@ -1,0 +1,43 @@
+package numeric
+
+var interleaveMagic = []uint64{
+	0x5555555555555555,
+	0x3333333333333333,
+	0x0F0F0F0F0F0F0F0F,
+	0x00FF00FF00FF00FF,
+	0x0000FFFF0000FFFF,
+	0x00000000FFFFFFFF,
+	0xAAAAAAAAAAAAAAAA,
+}
+
+var interleaveShift = []uint{1, 2, 4, 8, 16}
+
+// Interleave the first 32 bits of each uint64
+// apdated from org.apache.lucene.util.BitUtil
+// whcih was adapted from:
+// http://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN
+func Interleave(v1, v2 uint64) uint64 {
+	v1 = (v1 | (v1 << interleaveShift[4])) & interleaveMagic[4]
+	v1 = (v1 | (v1 << interleaveShift[3])) & interleaveMagic[3]
+	v1 = (v1 | (v1 << interleaveShift[2])) & interleaveMagic[2]
+	v1 = (v1 | (v1 << interleaveShift[1])) & interleaveMagic[1]
+	v1 = (v1 | (v1 << interleaveShift[0])) & interleaveMagic[0]
+	v2 = (v2 | (v2 << interleaveShift[4])) & interleaveMagic[4]
+	v2 = (v2 | (v2 << interleaveShift[3])) & interleaveMagic[3]
+	v2 = (v2 | (v2 << interleaveShift[2])) & interleaveMagic[2]
+	v2 = (v2 | (v2 << interleaveShift[1])) & interleaveMagic[1]
+	v2 = (v2 | (v2 << interleaveShift[0])) & interleaveMagic[0]
+	return (v2 << 1) | v1
+}
+
+// Deinterleave the 32-bit value starting at position 0
+// to get the other 32-bit value, shift it by 1 first
+func Deinterleave(b uint64) uint64 {
+	b &= interleaveMagic[0]
+	b = (b ^ (b >> interleaveShift[0])) & interleaveMagic[1]
+	b = (b ^ (b >> interleaveShift[1])) & interleaveMagic[2]
+	b = (b ^ (b >> interleaveShift[2])) & interleaveMagic[3]
+	b = (b ^ (b >> interleaveShift[3])) & interleaveMagic[4]
+	b = (b ^ (b >> interleaveShift[4])) & interleaveMagic[5]
+	return b
+}

--- a/document/numeric/bin_test.go
+++ b/document/numeric/bin_test.go
@@ -1,0 +1,27 @@
+package numeric
+
+import "testing"
+
+func TestInterleaveDeinterleave(t *testing.T) {
+	tests := []struct {
+		v1 uint64
+		v2 uint64
+	}{
+		{0, 0},
+		{1, 1},
+		{27, 39},
+		{1<<32 - 1, 1<<32 - 1}, // largest that should still work
+	}
+
+	for _, test := range tests {
+		i := Interleave(test.v1, test.v2)
+		gotv1 := Deinterleave(i)
+		gotv2 := Deinterleave(i >> 1)
+		if gotv1 != test.v1 {
+			t.Errorf("expected v1: %d, got %d, interleaved was %x", test.v1, gotv1, i)
+		}
+		if gotv2 != test.v2 {
+			t.Errorf("expected v2: %d, got %d, interleaved was %x", test.v2, gotv2, i)
+		}
+	}
+}

--- a/document/numeric/float.go
+++ b/document/numeric/float.go
@@ -1,0 +1,20 @@
+package numeric
+
+import (
+	"math"
+)
+
+func Float64ToInt64(f float64) int64 {
+	fasint := int64(math.Float64bits(f))
+	if fasint < 0 {
+		fasint = fasint ^ 0x7fffffffffffffff
+	}
+	return fasint
+}
+
+func Int64ToFloat64(i int64) float64 {
+	if i < 0 {
+		i ^= 0x7fffffffffffffff
+	}
+	return math.Float64frombits(uint64(i))
+}

--- a/document/numeric/float_test.go
+++ b/document/numeric/float_test.go
@@ -1,0 +1,50 @@
+package numeric
+
+import (
+	"testing"
+)
+
+// test that the float/sortable int operations work both ways
+// and that the corresponding integers sort the same as
+// the original floats would have
+func TestSortabledFloat64ToInt64(t *testing.T) {
+	tests := []struct {
+		input float64
+	}{
+		{
+			input: -4640094584139352638,
+		},
+		{
+			input: -167.42,
+		},
+		{
+			input: -1.11,
+		},
+		{
+			input: 0,
+		},
+		{
+			input: 3.14,
+		},
+		{
+			input: 167.42,
+		},
+	}
+
+	var lastInt64 *int64
+	for _, test := range tests {
+		actual := Float64ToInt64(test.input)
+		if lastInt64 != nil {
+			// check that this float is greater than the last one
+			if actual <= *lastInt64 {
+				t.Errorf("expected greater than prev, this: %d, last %d", actual, *lastInt64)
+			}
+		}
+		lastInt64 = &actual
+		convertedBack := Int64ToFloat64(actual)
+		// assert that we got back what we started with
+		if convertedBack != test.input {
+			t.Errorf("expected %f, got %f", test.input, convertedBack)
+		}
+	}
+}

--- a/document/numeric/prefix_coded.go
+++ b/document/numeric/prefix_coded.go
@@ -1,0 +1,78 @@
+package numeric
+
+import "fmt"
+
+const ShiftStartInt64 byte = 0x20
+
+// PrefixCoded is a byte array encoding of
+// 64-bit numeric values shifted by 0-63 bits
+type PrefixCoded []byte
+
+func NewPrefixCodedInt64(in int64, shift uint) (PrefixCoded, error) {
+	if shift > 63 {
+		return nil, fmt.Errorf("cannot shift %d, must be between 0 and 63", shift)
+	}
+
+	nChars := ((63 - shift) / 7) + 1
+	rv := make(PrefixCoded, nChars+1)
+	rv[0] = ShiftStartInt64 + byte(shift)
+
+	sortableBits := int64(uint64(in) ^ 0x8000000000000000)
+	sortableBits = int64(uint64(sortableBits) >> shift)
+	for nChars > 0 {
+		// Store 7 bits per byte for compatibility
+		// with UTF-8 encoding of terms
+		rv[nChars] = byte(sortableBits & 0x7f)
+		nChars--
+		sortableBits = int64(uint64(sortableBits) >> 7)
+	}
+	return rv, nil
+}
+
+func MustNewPrefixCodedInt64(in int64, shift uint) PrefixCoded {
+	rv, err := NewPrefixCodedInt64(in, shift)
+	if err != nil {
+		panic(err)
+	}
+	return rv
+}
+
+// Shift returns the number of bits shifted
+// returns 0 if in uninitialized state
+func (p PrefixCoded) Shift() (uint, error) {
+	if len(p) > 0 {
+		shift := p[0] - ShiftStartInt64
+		if shift < 0 || shift < 63 {
+			return uint(shift), nil
+		}
+	}
+	return 0, fmt.Errorf("invalid prefix coded value")
+}
+
+func (p PrefixCoded) Int64() (int64, error) {
+	shift, err := p.Shift()
+	if err != nil {
+		return 0, err
+	}
+	var sortableBits int64
+	for _, inbyte := range p[1:] {
+		sortableBits <<= 7
+		sortableBits |= int64(inbyte)
+	}
+	return int64(uint64((sortableBits << shift)) ^ 0x8000000000000000), nil
+}
+
+func ValidPrefixCodedTerm(p string) (bool, int) {
+	if len(p) > 0 {
+		if p[0] < ShiftStartInt64 || p[0] > ShiftStartInt64+63 {
+			return false, 0
+		}
+		shift := p[0] - ShiftStartInt64
+		nChars := ((63 - int(shift)) / 7) + 1
+		if len(p) != nChars+1 {
+			return false, 0
+		}
+		return true, int(shift)
+	}
+	return false, 0
+}

--- a/document/numeric/prefix_coded_test.go
+++ b/document/numeric/prefix_coded_test.go
@@ -1,0 +1,144 @@
+package numeric
+
+import (
+	"reflect"
+	"testing"
+)
+
+var tests = []struct {
+	input  int64
+	shift  uint
+	output PrefixCoded
+}{
+	{
+		input:  1,
+		shift:  0,
+		output: PrefixCoded{0x20, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+	},
+	{
+		input:  -1,
+		shift:  0,
+		output: PrefixCoded{0x20, 0x0, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f},
+	},
+	{
+		input:  -94582,
+		shift:  0,
+		output: PrefixCoded{0x20, 0x0, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7a, 0x1d, 0xa},
+	},
+	{
+		input:  314729851,
+		shift:  0,
+		output: PrefixCoded{0x20, 0x1, 0x0, 0x0, 0x0, 0x0, 0x1, 0x16, 0x9, 0x4a, 0x7b},
+	},
+	{
+		input:  314729851,
+		shift:  4,
+		output: PrefixCoded{0x24, 0x8, 0x0, 0x0, 0x0, 0x0, 0x9, 0x30, 0x4c, 0x57},
+	},
+	{
+		input:  314729851,
+		shift:  8,
+		output: PrefixCoded{0x28, 0x40, 0x0, 0x0, 0x0, 0x0, 0x4b, 0x4, 0x65},
+	},
+	{
+		input:  314729851,
+		shift:  16,
+		output: PrefixCoded{0x30, 0x20, 0x0, 0x0, 0x0, 0x0, 0x25, 0x42},
+	},
+	{
+		input:  314729851,
+		shift:  32,
+		output: PrefixCoded{0x40, 0x8, 0x0, 0x0, 0x0, 0x0},
+	},
+	{
+		input:  1234729851,
+		shift:  32,
+		output: PrefixCoded{0x40, 0x8, 0x0, 0x0, 0x0, 0x0},
+	},
+}
+
+// these array encoding values have been verified manually
+// against the lucene implementation
+func TestPrefixCoded(t *testing.T) {
+
+	for _, test := range tests {
+		actual, err := NewPrefixCodedInt64(test.input, test.shift)
+		if err != nil {
+			t.Error(err)
+		}
+		if !reflect.DeepEqual(actual, test.output) {
+			t.Errorf("expected %#v, got %#v", test.output, actual)
+		}
+		checkedShift, err := actual.Shift()
+		if err != nil {
+			t.Error(err)
+		}
+		if checkedShift != test.shift {
+			t.Errorf("expected %d, got %d", test.shift, checkedShift)
+		}
+		// if the shift was 0, make sure we can go back to the original
+		if test.shift == 0 {
+			backToLong, err := actual.Int64()
+			if err != nil {
+				t.Error(err)
+			}
+			if backToLong != test.input {
+				t.Errorf("expected %v, got %v", test.input, backToLong)
+			}
+		}
+	}
+}
+
+func TestPrefixCodedValid(t *testing.T) {
+	// all of the shared tests should be valid
+	for _, test := range tests {
+		valid, _ := ValidPrefixCodedTerm(string(test.output))
+		if !valid {
+			t.Errorf("expected %s to be valid prefix coded, is not", string(test.output))
+		}
+	}
+
+	invalidTests := []struct {
+		data PrefixCoded
+	}{
+		// first byte invalid skip (too low)
+		{
+			data: PrefixCoded{0x19, 'c', 'a', 't'},
+		},
+		// first byte invalid skip (too high)
+		{
+			data: PrefixCoded{0x20 + 64, 'c'},
+		},
+		// length of trailing bytes wrong (too long)
+		{
+			data: PrefixCoded{0x20, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+		},
+		// length of trailing bytes wrong (too short)
+		{
+			data: PrefixCoded{0x20 + 63},
+		},
+	}
+
+	// all of the shared tests should be valid
+	for _, test := range invalidTests {
+		valid, _ := ValidPrefixCodedTerm(string(test.data))
+		if valid {
+			t.Errorf("expected %s to be invalid prefix coded, it is", string(test.data))
+		}
+	}
+}
+
+func BenchmarkTestPrefixCoded(b *testing.B) {
+
+	for i := 0; i < b.N; i++ {
+		for _, test := range tests {
+			actual, err := NewPrefixCodedInt64(test.input, test.shift)
+			if err != nil {
+				b.Error(err)
+			}
+			if !reflect.DeepEqual(actual, test.output) {
+				b.Errorf("expected %#v, got %#v", test.output, actual)
+			}
+		}
+	}
+}

--- a/kernel/analysis/analysis.go
+++ b/kernel/analysis/analysis.go
@@ -1,0 +1,5 @@
+package analysis
+
+type Analyzer struct {
+	//TODO
+}

--- a/kernel/index.go
+++ b/kernel/index.go
@@ -1,0 +1,26 @@
+//the local storage & indexing engine for a partition
+package kernel
+
+import (
+	"github.com/tiglabs/baud/schema"
+)
+
+type Index interface {
+	Insert(uid schema.UID, document []byte) error
+	Search(*Request) (*Result, error)
+	Stat() (*Stats, error)
+}
+
+type Kernel struct{}
+
+func (i *Kernel) Insert(uid schema.UID, document []byte) error {
+	return nil
+}
+
+func (i *Kernel) Search(*Request) (*Result, error) {
+	return
+}
+
+func (i *Kernel) Stat() (*Stats, error) {
+	return
+}

--- a/kernel/mapping.go
+++ b/kernel/mapping.go
@@ -1,0 +1,1 @@
+package kernel

--- a/kernel/mapping/mapping.go
+++ b/kernel/mapping/mapping.go
@@ -1,0 +1,24 @@
+package mapping
+
+import "github.com/tiglabs/baud/document"
+
+// TODO
+type Mapper struct {
+
+}
+
+func (m *Mapper) GetFieldID(name string) (uint64, bool) {
+	return 0, true
+}
+
+func (m *Mapper) GetFieldName(id uint64) (string, bool) {
+	return "", true
+}
+
+func (m *Mapper) GetFieldTypeByID(id uint64) (document.FieldType, bool) {
+	return document.String, true
+}
+
+func (m *Mapper) GetFieldTypeByName(name string) (document.FieldType, bool) {
+	return document.String, true
+}

--- a/kernel/store/doc_store.go
+++ b/kernel/store/doc_store.go
@@ -1,0 +1,57 @@
+package store
+
+import (
+	"github.com/tiglabs/baud/document"
+	"github.com/tiglabs/baud/kernel/store/kvstore"
+	"github.com/tiglabs/baud/kernel/mapping"
+)
+
+type DocStore struct {
+	store       kvstore.KVStore
+	mapper      *mapping.Mapper
+}
+
+func NewDocStore(store kvstore.KVStore) *DocStore {
+	return &DocStore{store: store}
+}
+
+func(s *DocStore) InsertDoc(doc *document.Document) error {
+	// now we only store source
+	key := encodeStoreKey(doc.SlotID, doc.ID)
+	value := encodeStoreValue(doc.Source)
+
+	return s.store.Put(key, value)
+}
+
+func(s *DocStore) QueryDoc(slotID uint32, id string) (*document.Document, error) {
+	key := encodeStoreKey(slotID, id)
+	value, err := s.store.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	document.NewDocument(id, slotID, 0, value)
+	return nil, nil
+}
+
+func(s *DocStore) MultiQueryDoc(slotID uint32, ids []string) ([]*document.Document, error) {
+	var keys [][]byte
+	for _, id := range ids {
+		keys = append(keys, encodeStoreKey(slotID, id))
+	}
+	values, err := s.store.MultiGet(keys)
+	if err != nil {
+		return nil, err
+	}
+	var docs []*document.Document
+	for i, id := range ids {
+		docs = append(docs, document.NewDocument(id, slotID, 0, values[i]))
+	}
+	return docs, nil
+}
+
+func(s *DocStore) DeleteDoc(slotID uint32, id string) error {
+	key := encodeStoreKey(slotID, id)
+	return s.store.Delete(key)
+}
+
+func(s *DocStore) Close()

--- a/kernel/store/encoding.go
+++ b/kernel/store/encoding.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"fmt"
+	"encoding/binary"
+
+	"github.com/tiglabs/baud/util"
+)
+
+type KEY_TYPE byte
+
+const (
+	TYPE_S KEY_TYPE = 'S'
+	TYPE_F KEY_TYPE = 'F'
+)
+
+var KeyType_name = map[byte]string{
+	'S': "Source",
+	'F': "Field",
+}
+
+var KeyType_value = map[string]byte{
+	"Source":   'S',
+	"Field":    'F',
+}
+
+func (x KEY_TYPE) String() string {
+	s, ok := KeyType_name[byte(x)]
+	if ok {
+		return s
+	}
+	return "unknown"
+}
+
+// document 存储格式: <key>                       <value>
+//               [type]+[slot ID]+[doc ID]      [document]
+// slot ID 编码到key中可以方便整体迁移指定slot上的文档
+
+func decodeStoreKey(key []byte) (docID string, slotID uint32, err error) {
+	if len(key) <= 5 {
+		err = fmt.Errorf("key[%+v] can't be identified", key)
+		return
+	}
+	if key[0] != byte(TYPE_S) {
+		err = fmt.Errorf("invalid key type %s", KEY_TYPE(key[0]).String())
+		return
+	}
+	slotID = binary.BigEndian.Uint32(key[1:])
+	docID = util.SliceToString(key[5:])
+	return
+}
+
+func encodeStoreKey(slotID uint32, docID string) []byte {
+	key := make([]byte, 5 + len(docID))
+	key[0] = byte(TYPE_S)
+	binary.BigEndian.PutUint32(key[1:], slotID)
+	copy(key[5:], util.StringToSlice(docID))
+	return key
+}
+
+func encodeStoreValue(value []byte) []byte {
+	return value
+}
+
+func decodeStoreValue(value []byte) []byte {
+	return value
+}

--- a/kernel/store/kvstore/batch.go
+++ b/kernel/store/kvstore/batch.go
@@ -1,0 +1,65 @@
+package kvstore
+
+var _ Operation = &op{}
+var _ KVBatch = &Batch{}
+
+type Operation interface {
+	Key() []byte
+	Value() []byte
+}
+
+type op struct {
+	K []byte
+	V []byte
+}
+
+func (o *op)Key() []byte {
+	if o == nil {
+		return nil
+	}
+	return o.K
+}
+
+func (o *op)Value() []byte {
+	if o == nil {
+		return nil
+	}
+	return o.V
+}
+
+type Batch struct {
+	Ops    []Operation
+}
+
+func NewBatch() *Batch {
+	return &Batch{
+		Ops:    make([]Operation, 0, 1000),
+	}
+}
+
+func (b *Batch) Set(key, val []byte) {
+	ck := make([]byte, len(key))
+	copy(ck, key)
+	cv := make([]byte, len(val))
+	copy(cv, val)
+	b.Ops = append(b.Ops, &op{ck, cv})
+}
+
+func (b *Batch) Delete(key []byte) {
+	ck := make([]byte, len(key))
+	copy(ck, key)
+	b.Ops = append(b.Ops, &op{ck, nil})
+}
+
+func (b *Batch) Operations() []Operation {
+	return b.Ops
+}
+
+// for reuse
+func (b *Batch) Reset() {
+	b.Ops = b.Ops[:0]
+}
+
+func (b *Batch) Close() error {
+	return nil
+}

--- a/kernel/store/kvstore/boltdb/iterator.go
+++ b/kernel/store/kvstore/boltdb/iterator.go
@@ -1,0 +1,102 @@
+package boltdb
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/boltdb/bolt"
+	"github.com/tiglabs/baud/kernel/store/kvstore"
+)
+
+var _ kvstore.KVIterator = &Iterator{}
+
+type Iterator struct {
+	close  sync.Once
+	tx     *bolt.Tx
+	cursor *bolt.Cursor
+	prefix []byte
+	start  []byte
+	end    []byte
+	valid  bool
+	key    []byte
+	val    []byte
+}
+
+func (i *Iterator) updateValid() {
+	i.valid = (i.key != nil)
+	if i.valid {
+		if i.prefix != nil {
+			i.valid = bytes.HasPrefix(i.key, i.prefix)
+		} else if i.end != nil {
+			i.valid = bytes.Compare(i.key, i.end) < 0
+		}
+	}
+}
+
+func (i *Iterator) Seek(k []byte) {
+	if i == nil {
+		return
+	}
+	if i.start != nil && bytes.Compare(k, i.start) < 0 {
+		k = i.start
+	}
+	if i.prefix != nil && !bytes.HasPrefix(k, i.prefix) {
+		if bytes.Compare(k, i.prefix) < 0 {
+			k = i.prefix
+		} else {
+			i.valid = false
+			return
+		}
+	}
+	i.key, i.val = i.cursor.Seek(k)
+	i.updateValid()
+}
+
+func (i *Iterator) Next() {
+	if i == nil {
+		return
+	}
+	i.key, i.val = i.cursor.Next()
+	i.updateValid()
+}
+
+func (i *Iterator) Current() ([]byte, []byte, bool) {
+	if i == nil {
+		return nil, nil, false
+	}
+	return i.key, i.val, i.valid
+}
+
+func (i *Iterator) Key() []byte {
+	if i == nil {
+		return nil
+	}
+	return i.key
+}
+
+func (i *Iterator) Value() []byte {
+	if i == nil {
+		return nil
+	}
+	return i.val
+}
+
+func (i *Iterator) Valid() bool {
+	if i == nil {
+		return false
+	}
+	return i.valid
+}
+
+func (i *Iterator) Close() error {
+	if i == nil {
+		return nil
+	}
+	i.close.Do(func() {
+		if i.tx != nil {
+			i.tx.Rollback()
+		}
+	})
+
+	return nil
+}

--- a/kernel/store/kvstore/boltdb/reader.go
+++ b/kernel/store/kvstore/boltdb/reader.go
@@ -1,0 +1,71 @@
+package boltdb
+
+import (
+	"github.com/boltdb/bolt"
+	"github.com/tiglabs/baud/kernel/store/kvstore"
+)
+
+type Reader struct {
+	tx     *bolt.Tx
+	bucket *bolt.Bucket
+}
+
+func (r *Reader) Get(key []byte) ([]byte, error) {
+	if r == nil {
+		return nil, nil
+	}
+	var rv []byte
+	v := r.bucket.Get(key)
+	if v != nil {
+		rv = make([]byte, len(v))
+		copy(rv, v)
+	}
+	return rv, nil
+}
+
+func (r *Reader) MultiGet(keys [][]byte) ([][]byte, error) {
+	if r == nil {
+		return nil, nil
+	}
+	return kvstore.MultiGet(r, keys)
+}
+
+func (r *Reader) PrefixIterator(prefix []byte) kvstore.KVIterator {
+	if r == nil {
+		return nil
+	}
+	cursor := r.bucket.Cursor()
+
+	rv := &Iterator{
+		// we must not set tx here
+		cursor: cursor,
+		prefix: prefix,
+	}
+
+	rv.Seek(prefix)
+	return rv
+}
+
+func (r *Reader) RangeIterator(start, end []byte) kvstore.KVIterator {
+	if r == nil {
+		return nil
+	}
+	cursor := r.bucket.Cursor()
+
+	rv := &Iterator{
+		// we must not set tx here
+		cursor: cursor,
+		start:  start,
+		end:    end,
+	}
+
+	rv.Seek(start)
+	return rv
+}
+
+func (r *Reader) Close() error {
+	if r == nil {
+		return nil
+	}
+	return r.tx.Rollback()
+}

--- a/kernel/store/kvstore/boltdb/stats.go
+++ b/kernel/store/kvstore/boltdb/stats.go
@@ -1,0 +1,12 @@
+package boltdb
+
+import "encoding/json"
+
+type stats struct {
+	s *Store
+}
+
+func (s *stats) MarshalJSON() ([]byte, error) {
+	bs := s.s.db.Stats()
+	return json.Marshal(bs)
+}

--- a/kernel/store/kvstore/boltdb/store.go
+++ b/kernel/store/kvstore/boltdb/store.go
@@ -1,0 +1,225 @@
+package boltdb
+
+import (
+	"os"
+	"errors"
+
+	"github.com/boltdb/bolt"
+	"github.com/tiglabs/baud/kernel/store/kvstore"
+)
+
+type StoreConfig struct {
+	Path       string
+	Bucket     string
+	NoSync     bool
+	ReadOnly   bool
+	FillPercent float64
+}
+
+type Store struct {
+	path        string
+	bucket      []byte
+	db          *bolt.DB
+	noSync      bool
+	fillPercent float64
+}
+
+func New(config *StoreConfig) (kvstore.KVStore, error) {
+	if config == nil {
+		return nil, errors.New("must provide config")
+	}
+	if config.Path == "" {
+		return nil, os.ErrInvalid
+	}
+	path := config.Path
+	bucket := config.Bucket
+	if config.Bucket == "" {
+		bucket = "baud"
+	}
+	noSync := config.NoSync
+	fillPercent := config.FillPercent
+	if fillPercent == 0.0 {
+		fillPercent = bolt.DefaultFillPercent
+	}
+
+	bo := &bolt.Options{}
+	bo.ReadOnly = config.ReadOnly
+
+	db, err := bolt.Open(path, 0600, bo)
+	if err != nil {
+		return nil, err
+	}
+	db.NoSync = noSync
+
+	if !bo.ReadOnly {
+		err = db.Update(func(tx *bolt.Tx) error {
+			_, err := tx.CreateBucketIfNotExists([]byte(bucket))
+
+			return err
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	rv := Store{
+		path:        path,
+		bucket:      []byte(bucket),
+		db:          db,
+		noSync:      noSync,
+		fillPercent: fillPercent,
+	}
+	return &rv, nil
+}
+
+func (bs *Store)Get(key []byte) (value []byte, err error) {
+	if bs == nil {
+		return nil, nil
+	}
+	err = bs.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bs.bucket)
+		v := b.Get(key)
+		if v != nil {
+			value = cloneBytes(v)
+		}
+		return nil
+	})
+	return
+}
+
+func (bs *Store)Put(key []byte, value []byte) error {
+	if bs == nil {
+		return nil
+	}
+	return bs.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bs.bucket)
+		err := b.Put(key, value)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (bs *Store)Delete(key []byte) error {
+	if bs == nil {
+		return nil
+	}
+	return bs.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bs.bucket)
+		err := b.Delete(key)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (bs *Store)MultiGet(keys [][]byte) ([][]byte, error) {
+	if bs == nil {
+		return nil, nil
+	}
+	r, err := bs.Reader()
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return r.MultiGet(keys)
+}
+
+func (bs *Store) Reader() (kvstore.KVReader, error) {
+	tx, err := bs.db.Begin(false)
+	if err != nil {
+		return nil, err
+	}
+	return &Reader{
+		tx:     tx,
+		bucket: tx.Bucket(bs.bucket),
+	}, nil
+}
+
+func (bs *Store)PrefixIterator(prefix []byte) kvstore.KVIterator {
+	tx, err := bs.db.Begin(false)
+	if err != nil {
+		return nil
+	}
+	cursor := tx.Bucket([]byte(bs.bucket)).Cursor()
+
+	rv := &Iterator{
+		tx:     tx,
+		cursor: cursor,
+		prefix: prefix,
+	}
+
+	rv.Seek(prefix)
+	return rv
+}
+
+func (bs *Store)RangeIterator(start, end []byte) kvstore.KVIterator {
+	tx, err := bs.db.Begin(false)
+	if err != nil {
+		return nil
+	}
+	cursor := tx.Bucket([]byte(bs.bucket)).Cursor()
+	rv := &Iterator{
+		tx:     tx,
+		cursor: cursor,
+		start:  start,
+		end:    end,
+	}
+
+	rv.Seek(start)
+	return rv
+}
+
+func (bs *Store)NewKVBatch() kvstore.KVBatch {
+	return kvstore.NewBatch()
+}
+
+func (bs *Store)ExecuteBatch(batch kvstore.KVBatch) (err error) {
+	if bs == nil {
+		return nil
+	}
+	if batch == nil {
+		return nil
+	}
+	var tx *bolt.Tx
+	tx, err = bs.db.Begin(true)
+	if err != nil {
+		return
+	}
+
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+		} else {
+			_ = tx.Rollback()
+		}
+	}()
+
+	bucket := tx.Bucket([]byte(bs.bucket))
+	bucket.FillPercent = bs.fillPercent
+
+	for _, op := range batch.Operations() {
+		if op.Value() != nil {
+			err = bucket.Put(op.Key(), op.Value())
+			if err != nil {
+				return
+			}
+		} else {
+			err = bucket.Delete(op.Key())
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+func (bs *Store) Close() error {
+	return bs.db.Close()
+}
+
+func cloneBytes(b []byte) []byte {
+	return append([]byte(nil), b...)
+}

--- a/kernel/store/kvstore/boltdb/store_test.go
+++ b/kernel/store/kvstore/boltdb/store_test.go
@@ -1,0 +1,140 @@
+//  Copyright (c) 2014 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package boltdb
+
+import (
+	"os"
+	"testing"
+
+	"github.com/boltdb/bolt"
+	"github.com/tiglabs/baud/kernel/store/kvstore"
+	"github.com/tiglabs/baud/kernel/store/kvstore/test"
+)
+
+func open(t *testing.T) kvstore.KVStore {
+	rv, err := New(&StoreConfig{Path: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rv
+}
+
+func cleanup(t *testing.T, s kvstore.KVStore) {
+	err := s.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.RemoveAll("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBoltDBKVCrud(t *testing.T) {
+	s := open(t)
+	defer cleanup(t, s)
+	test.CommonTestKVCrud(t, s)
+}
+
+func TestBoltDBReaderIsolation(t *testing.T) {
+	s := open(t)
+	defer cleanup(t, s)
+	test.CommonTestReaderIsolation(t, s)
+}
+
+func TestBoltDBReaderOwnsGetBytes(t *testing.T) {
+	s := open(t)
+	defer cleanup(t, s)
+	test.CommonTestReaderOwnsGetBytes(t, s)
+}
+
+func TestBoltDBWriterOwnsBytes(t *testing.T) {
+	s := open(t)
+	defer cleanup(t, s)
+	test.CommonTestWriterOwnsBytes(t, s)
+}
+
+func TestBoltDBPrefixIterator(t *testing.T) {
+	s := open(t)
+	defer cleanup(t, s)
+	test.CommonTestPrefixIterator(t, s)
+}
+
+func TestBoltDBPrefixIteratorSeek(t *testing.T) {
+	s := open(t)
+	defer cleanup(t, s)
+	test.CommonTestPrefixIteratorSeek(t, s)
+}
+
+func TestBoltDBRangeIterator(t *testing.T) {
+	s := open(t)
+	defer cleanup(t, s)
+	test.CommonTestRangeIterator(t, s)
+}
+
+func TestBoltDBRangeIteratorSeek(t *testing.T) {
+	s := open(t)
+	defer cleanup(t, s)
+	test.CommonTestRangeIteratorSeek(t, s)
+}
+
+func TestBoltDBConfig(t *testing.T) {
+	var tests = []struct {
+		in          *StoreConfig
+		path        string
+		bucket      string
+		noSync      bool
+		fillPercent float64
+	}{
+		{
+			&StoreConfig{Path: "test", Bucket: "mybucket", NoSync: true, FillPercent: 0.75},
+			"test",
+			"mybucket",
+			true,
+			0.75,
+		},
+		{
+			&StoreConfig{Path: "test"},
+			"test",
+			"baud",
+			false,
+			bolt.DefaultFillPercent,
+		},
+	}
+
+	for _, test := range tests {
+		kv, err := New(test.in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bs, ok := kv.(*Store)
+		if !ok {
+			t.Fatal("failed type assertion to *boltdb.Store")
+		}
+		if bs.path != test.path {
+			t.Fatalf("path: expected %q, got %q", test.path, bs.path)
+		}
+		if string(bs.bucket) != test.bucket {
+			t.Fatalf("bucket: expected %q, got %q", test.bucket, bs.bucket)
+		}
+		if bs.noSync != test.noSync {
+			t.Fatalf("noSync: expected %t, got %t", test.noSync, bs.noSync)
+		}
+		if bs.fillPercent != test.fillPercent {
+			t.Fatalf("fillPercent: expected %f, got %f", test.fillPercent, bs.fillPercent)
+		}
+		cleanup(t, kv)
+	}
+}

--- a/kernel/store/kvstore/kvstore.go
+++ b/kernel/store/kvstore/kvstore.go
@@ -1,0 +1,124 @@
+package kvstore
+
+type KVStore interface {
+	Put(key, value []byte) error
+	Get(key []byte) ([]byte, error)
+	Delete(key []byte) error
+
+	// MultiGet retrieves multiple values in one call.
+	MultiGet(keys [][]byte) ([][]byte, error)
+
+	// PrefixIterator returns a KVIterator that will
+	// visit all K/V pairs with the provided prefix
+	PrefixIterator(prefix []byte) KVIterator
+
+	// RangeIterator returns a KVIterator that will
+	// visit all K/V pairs >= start AND < end
+	RangeIterator(start, end []byte) KVIterator
+
+	NewKVBatch() KVBatch
+	ExecuteBatch(batch KVBatch) error
+
+	// Reader returns a KVReader which can be used to
+	// read data from the KVStore.  If a reader cannot
+	// be obtained a non-nil error is returned.
+	Reader() (KVReader, error)
+	Close() error
+}
+
+// KVReader is an abstraction of an **ISOLATED** reader
+// In this context isolated is defined to mean that
+// writes/deletes made after the KVReader is opened
+// are not observed.
+// Because there is usually a cost associated with
+// keeping isolated readers active, users should
+// close them as soon as they are no longer needed.
+type KVReader interface {
+
+	// Get returns the value associated with the key
+	// If the key does not exist, nil is returned.
+	// The caller owns the bytes returned.
+	Get(key []byte) ([]byte, error)
+
+	// MultiGet retrieves multiple values in one call.
+	MultiGet(keys [][]byte) ([][]byte, error)
+
+	// PrefixIterator returns a KVIterator that will
+	// visit all K/V pairs with the provided prefix
+	PrefixIterator(prefix []byte) KVIterator
+
+	// RangeIterator returns a KVIterator that will
+	// visit all K/V pairs >= start AND < end
+	RangeIterator(start, end []byte) KVIterator
+
+	// Close closes the iterator
+	Close() error
+}
+
+
+// KVIterator is an abstraction around key iteration
+type KVIterator interface {
+
+	// Seek will advance the iterator to the specified key
+	Seek(key []byte)
+
+	// Next will advance the iterator to the next key
+	Next()
+
+	// Key returns the key pointed to by the iterator
+	// The bytes returned are **ONLY** valid until the next call to Seek/Next/Close
+	// Continued use after that requires that they be copied.
+	Key() []byte
+
+	// Value returns the value pointed to by the iterator
+	// The bytes returned are **ONLY** valid until the next call to Seek/Next/Close
+	// Continued use after that requires that they be copied.
+	Value() []byte
+
+	// Valid returns whether or not the iterator is in a valid state
+	Valid() bool
+
+	// Current returns Key(),Value(),Valid() in a single operation
+	Current() ([]byte, []byte, bool)
+
+	// Close closes the iterator
+	Close() error
+}
+
+type KVBatch interface {
+
+	// Set updates the key with the specified value
+	// both key and value []byte may be reused as soon as this call returns
+	Set(key, val []byte)
+
+	// Delete removes the specified key
+	// the key []byte may be reused as soon as this call returns
+	Delete(key []byte)
+
+	// Return all operation
+	Operations() []Operation
+
+	// Reset frees resources for this batch and allows reuse
+	Reset()
+
+	// Close frees resources
+	Close() error
+}
+
+// MultiGet is a helper function to retrieve mutiple keys from a
+// KVReader, and might be used by KVStore implementations that don't
+// have a native multi-get facility.
+func MultiGet(reader KVReader, keys [][]byte) ([][]byte, error) {
+	vals := make([][]byte, 0, len(keys))
+
+	for i, key := range keys {
+		val, err := reader.Get(key)
+		if err != nil {
+			return nil, err
+		}
+
+		vals[i] = val
+	}
+
+	return vals, nil
+}

--- a/kernel/store/kvstore/null/null.go
+++ b/kernel/store/kvstore/null/null.go
@@ -1,0 +1,103 @@
+package null
+
+import (
+	"github.com/tiglabs/baud/kernel/store/kvstore"
+)
+
+var _ kvstore.KVStore = &Store{}
+
+type Store struct{}
+
+func New() (kvstore.KVStore, error) {
+	return &Store{}, nil
+}
+
+func (r *Store) Get(key []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func (r *Store) MultiGet(keys [][]byte) ([][]byte, error) {
+	return make([][]byte, len(keys)), nil
+}
+
+func (r *Store) PrefixIterator(prefix []byte) kvstore.KVIterator {
+	return &iterator{}
+}
+
+func (r *Store) RangeIterator(start, end []byte) kvstore.KVIterator {
+	return &iterator{}
+}
+
+func (w *Store) NewBatch() kvstore.KVBatch {
+	return &batch{}
+}
+
+func (w *Store) ExecuteBatch(kvstore.KVBatch) error {
+	return nil
+}
+
+func (r *Store) Close() error {
+	return nil
+}
+
+type iterator struct{}
+
+func (i *iterator) SeekFirst()    {}
+func (i *iterator) Seek(k []byte) {}
+func (i *iterator) Next()         {}
+
+func (i *iterator) Current() ([]byte, []byte, bool) {
+	return nil, nil, false
+}
+
+func (i *iterator) Key() []byte {
+	return nil
+}
+
+func (i *iterator) Value() []byte {
+	return nil
+}
+
+func (i *iterator) Valid() bool {
+	return false
+}
+
+func (i *iterator) Close() error {
+	return nil
+}
+
+
+func (i *Store) Reader() (kvstore.KVReader, error) {
+	return &reader{}, nil
+}
+
+type reader struct{}
+
+func (r *reader) Get(key []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func (r *reader) MultiGet(keys [][]byte) ([][]byte, error) {
+	return make([][]byte, len(keys)), nil
+}
+
+func (r *reader) PrefixIterator(prefix []byte) kvstore.KVIterator {
+	return &iterator{}
+}
+
+func (r *reader) RangeIterator(start, end []byte) kvstore.KVIterator {
+	return &iterator{}
+}
+
+func (r *reader) Close() error {
+	return nil
+}
+
+type batch struct{}
+
+func (i *batch) Set(key, val []byte)   {}
+func (i *batch) Delete(key []byte)     {}
+func (i *batch) Merge(key, val []byte) {}
+func (i *batch) Reset()                {}
+func (i *batch) Operations() []kvstore.Operation { return nil }
+func (i *batch) Close() error          { return nil }

--- a/kernel/store/kvstore/null/null_test.go
+++ b/kernel/store/kvstore/null/null_test.go
@@ -1,0 +1,92 @@
+//  Copyright (c) 2014 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package null
+
+import (
+	"testing"
+
+	"github.com/tiglabs/baud/kernel/store/kvstore"
+)
+
+func TestStore(t *testing.T) {
+	s, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	NullTestKVStore(t, s)
+}
+
+// NullTestKVStore has very different expectations
+// compared to CommonTestKVStore
+func NullTestKVStore(t *testing.T, s kvstore.KVStore) {
+
+	writer, err := s.Writer()
+	if err != nil {
+		t.Error(err)
+	}
+
+	batch := writer.NewBatch()
+	batch.Set([]byte("b"), []byte("val-b"))
+	batch.Set([]byte("c"), []byte("val-c"))
+	batch.Set([]byte("d"), []byte("val-d"))
+	batch.Set([]byte("e"), []byte("val-e"))
+	batch.Set([]byte("f"), []byte("val-f"))
+	batch.Set([]byte("g"), []byte("val-g"))
+	batch.Set([]byte("h"), []byte("val-h"))
+	batch.Set([]byte("i"), []byte("val-i"))
+	batch.Set([]byte("j"), []byte("val-j"))
+
+	err = writer.ExecuteBatch(batch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = writer.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := s.Reader()
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err := reader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	it := reader.RangeIterator([]byte("b"), nil)
+	key, val, valid := it.Current()
+	if valid {
+		t.Fatalf("valid true, expected false")
+	}
+	if key != nil {
+		t.Fatalf("expected key nil, got %s", key)
+	}
+	if val != nil {
+		t.Fatalf("expected value nil, got %s", val)
+	}
+
+	err = it.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = s.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/kernel/store/kvstore/test/README.md
+++ b/kernel/store/kvstore/test/README.md
@@ -1,0 +1,11 @@
+# Generic KVStore implementation tests
+
+These are a set of common tests that should pass on any correct KVStore implementation.
+
+Each test function in this package has the form:
+
+    func CommonTest<name>(t *testing.T, s store.KVStore) {...}
+
+A KVStore implementation test should use the same name, including its own KVStore name in the test function.  It should instantiate an instance of the store, and pass the testing.T and store to the common function.
+
+The common test functions should *NOT* close the KVStore.  The KVStore test implementation should close the store and cleanup any state.

--- a/kernel/store/kvstore/test/bytes.go
+++ b/kernel/store/kvstore/test/bytes.go
@@ -1,0 +1,179 @@
+package test
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/tiglabs/baud/kernel/store/kvstore"
+)
+
+// tests which focus on the byte ownership
+
+// CommonTestReaderOwnsGetBytes attempts to mutate the returned bytes
+// first, while the reader is still open, second after that reader is
+// closed, then the original key is read again, to ensure these
+// modifications did not cause panic, or mutate the stored value
+func CommonTestReaderOwnsGetBytes(t *testing.T, s kvstore.KVStore) {
+
+	originalKey := []byte("key")
+	originalVal := []byte("val")
+
+	// write key/val
+	batch := s.NewKVBatch()
+	batch.Set(originalKey, originalVal)
+	err := s.ExecuteBatch(batch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// read key
+	returnedVal, err := s.Get(originalKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check that it is the expected value
+	if !reflect.DeepEqual(returnedVal, originalVal) {
+		t.Fatalf("expected value: %v for '%s', got %v", originalVal, originalKey, returnedVal)
+	}
+
+	// mutate the returned value with reader still open
+	for i := range returnedVal {
+		returnedVal[i] = '1'
+	}
+
+	// read the key again
+	returnedVal2, err := s.Get(originalKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check that it is the expected value
+	if !reflect.DeepEqual(returnedVal2, originalVal) {
+		t.Fatalf("expected value: %v for '%s', got %v", originalVal, originalKey, returnedVal2)
+	}
+
+	// mutate the original returned value again
+	for i := range returnedVal {
+		returnedVal[i] = '2'
+	}
+
+	// read the key again
+	returnedVal3, err := s.Get(originalKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check that it is the expected value
+	if !reflect.DeepEqual(returnedVal3, originalVal) {
+		t.Fatalf("expected value: %v for '%s', got %v", originalVal, originalKey, returnedVal3)
+	}
+
+	// finally check that the value we mutated still has what we set it to
+	for i := range returnedVal {
+		if returnedVal[i] != '2' {
+			t.Errorf("expected byte to be '2', got %v", returnedVal[i])
+		}
+	}
+}
+
+func CommonTestWriterOwnsBytes(t *testing.T, s kvstore.KVStore) {
+
+	keyBuffer := make([]byte, 5)
+	valBuffer := make([]byte, 5)
+
+	// write key/val pairs reusing same buffer
+	batch := s.NewKVBatch()
+	for i := 0; i < 10; i++ {
+		keyBuffer[0] = 'k'
+		keyBuffer[1] = 'e'
+		keyBuffer[2] = 'y'
+		keyBuffer[3] = '-'
+		keyBuffer[4] = byte('0' + i)
+		valBuffer[0] = 'v'
+		valBuffer[1] = 'a'
+		valBuffer[2] = 'l'
+		valBuffer[3] = '-'
+		valBuffer[4] = byte('0' + i)
+		batch.Set(keyBuffer, valBuffer)
+	}
+	err := s.ExecuteBatch(batch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check that we can read back what we expect
+	allks := make([][]byte, 0)
+	allvs := make([][]byte, 0)
+	iter := s.RangeIterator(nil, nil)
+	for iter.Valid() {
+		// if we want to keep bytes from iteration we must copy
+		k := iter.Key()
+		copyk := make([]byte, len(k))
+		copy(copyk, k)
+		allks = append(allks, copyk)
+		v := iter.Key()
+		copyv := make([]byte, len(v))
+		copy(copyv, v)
+		allvs = append(allvs, copyv)
+		iter.Next()
+	}
+	err = iter.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(allks) != 10 {
+		t.Fatalf("expected 10 k/v pairs, got %d", len(allks))
+	}
+	for i, key := range allks {
+		val := allvs[i]
+		if !bytes.HasSuffix(key, []byte{byte('0' + i)}) {
+			t.Errorf("expected key %v to end in %d", key, []byte{byte('0' + i)})
+		}
+		if !bytes.HasSuffix(val, []byte{byte('0' + i)}) {
+			t.Errorf("expected val %v to end in %d", val, []byte{byte('0' + i)})
+		}
+	}
+
+	// now delete using same approach
+	batch = s.NewKVBatch()
+	for i := 0; i < 10; i++ {
+		keyBuffer[0] = 'k'
+		keyBuffer[1] = 'e'
+		keyBuffer[2] = 'y'
+		keyBuffer[3] = '-'
+		keyBuffer[4] = byte('0' + i)
+		batch.Delete(keyBuffer)
+	}
+	err = s.ExecuteBatch(batch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+
+	// check that we can read back what we expect
+	allks = make([][]byte, 0)
+	iter = s.RangeIterator(nil, nil)
+	for iter.Valid() {
+		// if we want to keep bytes from iteration we must copy
+		k := iter.Key()
+		copyk := make([]byte, len(k))
+		copy(copyk, k)
+		allks = append(allks, copyk)
+		v := iter.Key()
+		copyv := make([]byte, len(v))
+		copy(copyv, v)
+		allvs = append(allvs, copyv)
+		iter.Next()
+	}
+	err = iter.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(allks) != 0 {
+		t.Fatalf("expected 0 k/v pairs remaining, got %d", len(allks))
+	}
+}

--- a/kernel/store/kvstore/test/crud.go
+++ b/kernel/store/kvstore/test/crud.go
@@ -1,0 +1,78 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/tiglabs/baud/kernel/store/kvstore"
+)
+
+// basic crud tests
+
+func CommonTestKVCrud(t *testing.T, s kvstore.KVStore) {
+	batch := s.NewKVBatch()
+	batch.Set([]byte("a"), []byte("val-a"))
+	batch.Set([]byte("z"), []byte("val-z"))
+	batch.Delete([]byte("z"))
+	err := s.ExecuteBatch(batch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	batch.Reset()
+
+	batch.Set([]byte("b"), []byte("val-b"))
+	batch.Set([]byte("c"), []byte("val-c"))
+	batch.Set([]byte("d"), []byte("val-d"))
+	batch.Set([]byte("e"), []byte("val-e"))
+	batch.Set([]byte("f"), []byte("val-f"))
+	batch.Set([]byte("g"), []byte("val-g"))
+	batch.Set([]byte("h"), []byte("val-h"))
+	batch.Set([]byte("i"), []byte("val-i"))
+	batch.Set([]byte("j"), []byte("val-j"))
+
+	err = s.ExecuteBatch(batch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	it := s.RangeIterator([]byte("b"), nil)
+	key, val, valid := it.Current()
+	if !valid {
+		t.Fatalf("valid false, expected true")
+	}
+	if string(key) != "b" {
+		t.Fatalf("expected key b, got %s", key)
+	}
+	if string(val) != "val-b" {
+		t.Fatalf("expected value val-b, got %s", val)
+	}
+
+	it.Next()
+	key, val, valid = it.Current()
+	if !valid {
+		t.Fatalf("valid false, expected true")
+	}
+	if string(key) != "c" {
+		t.Fatalf("expected key c, got %s", key)
+	}
+	if string(val) != "val-c" {
+		t.Fatalf("expected value val-c, got %s", val)
+	}
+
+	it.Seek([]byte("i"))
+	key, val, valid = it.Current()
+	if !valid {
+		t.Fatalf("valid false, expected true")
+	}
+	if string(key) != "i" {
+		t.Fatalf("expected key i, got %s", key)
+	}
+	if string(val) != "val-i" {
+		t.Fatalf("expected value val-i, got %s", val)
+	}
+
+	err = it.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/kernel/store/kvstore/test/isolation.go
+++ b/kernel/store/kvstore/test/isolation.go
@@ -1,0 +1,138 @@
+package test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/tiglabs/baud/kernel/store/kvstore"
+)
+
+func CommonTestReaderIsolation(t *testing.T, s kvstore.KVStore) {
+	hackSize := 1000
+	batch := s.NewKVBatch()
+	for i := 0; i < hackSize; i++ {
+		k := fmt.Sprintf("x%d", i)
+		batch.Set([]byte(k), []byte("filler"))
+	}
+	err := s.ExecuteBatch(batch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// **************************************************
+
+	batch = s.NewKVBatch()
+	batch.Set([]byte("a"), []byte("val-a"))
+	err = s.ExecuteBatch(batch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create an isolated reader
+	reader, err := s.Reader()
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err := reader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// verify that we see the value already inserted
+	val, err := reader.Get([]byte("a"))
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(val, []byte("val-a")) {
+		t.Errorf("expected val-a, got nil")
+	}
+
+	// verify that an iterator sees it
+	count := 0
+	it := reader.RangeIterator([]byte{0}, []byte{'x'})
+	defer func() {
+		err := it.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	for it.Valid() {
+		it.Next()
+		count++
+	}
+	if count != 1 {
+		t.Errorf("expected iterator to see 1, saw %d", count)
+	}
+
+	batch = s.NewKVBatch()
+	batch.Set([]byte("b"), []byte("val-b"))
+	err = s.ExecuteBatch(batch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ensure that a newer reader sees it
+	newReader, err := s.Reader()
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		err := newReader.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	val, err = newReader.Get([]byte("b"))
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(val, []byte("val-b")) {
+		t.Errorf("expected val-b, got nil")
+	}
+
+	// ensure that the direct iterator sees it
+	count = 0
+	it2 := newReader.RangeIterator([]byte{0}, []byte{'x'})
+	defer func() {
+		err := it2.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	for it2.Valid() {
+		it2.Next()
+		count++
+	}
+	if count != 2 {
+		t.Errorf("expected iterator to see 2, saw %d", count)
+	}
+
+	// but that the isolated reader does not
+	val, err = reader.Get([]byte("b"))
+	if err != nil {
+		t.Error(err)
+	}
+	if val != nil {
+		t.Errorf("expected nil, got %v", val)
+	}
+
+	// and ensure that the iterator on the isolated reader also does not
+	count = 0
+	it3 := reader.RangeIterator([]byte{0}, []byte{'x'})
+	defer func() {
+		err := it3.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	for it3.Valid() {
+		it3.Next()
+		count++
+	}
+	if count != 1 {
+		t.Errorf("expected iterator to see 1, saw %d", count)
+	}
+
+}

--- a/kernel/store/kvstore/test/iterator.go
+++ b/kernel/store/kvstore/test/iterator.go
@@ -1,0 +1,365 @@
+package test
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/tiglabs/baud/kernel/store/kvstore"
+)
+
+// tests around the correct behavior of iterators
+
+type testRow struct {
+	key []byte
+	val []byte
+}
+
+func batchWriteRows(s kvstore.KVStore, rows []testRow) error {
+	// write the data
+	batch := s.NewKVBatch()
+	for _, row := range rows {
+		batch.Set(row.key, row.val)
+	}
+	err := s.ExecuteBatch(batch)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func CommonTestPrefixIterator(t *testing.T, s kvstore.KVStore) {
+
+	data := []testRow{
+		{[]byte("apple"), []byte("val")},
+		{[]byte("cat1"), []byte("val")},
+		{[]byte("cat2"), []byte("val")},
+		{[]byte("cat3"), []byte("val")},
+		{[]byte("dog1"), []byte("val")},
+		{[]byte("dog2"), []byte("val")},
+		{[]byte("dog4"), []byte("val")},
+		{[]byte("elephant"), []byte("val")},
+	}
+
+	expectedCats := [][]byte{
+		[]byte("cat1"),
+		[]byte("cat2"),
+		[]byte("cat3"),
+	}
+
+	expectedDogs := [][]byte{
+		[]byte("dog1"),
+		// we seek to "dog3" and ensure it skips over "dog2"
+		// but still finds "dog4" even though there was no "dog3"
+		[]byte("dog4"),
+	}
+
+	err := batchWriteRows(s, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get a prefix reader
+	cats := make([][]byte, 0)
+	iter := s.PrefixIterator([]byte("cat"))
+	for iter.Valid() {
+		// if we want to keep bytes from iteration we must copy
+		k := iter.Key()
+		copyk := make([]byte, len(k))
+		copy(copyk, k)
+		cats = append(cats, copyk)
+		iter.Next()
+	}
+	err = iter.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check that we found all the cats
+	if !reflect.DeepEqual(cats, expectedCats) {
+		t.Fatalf("expected cats %v, got %v", expectedCats, cats)
+	}
+
+	// get a prefix reader
+	dogs := make([][]byte, 0)
+	iter = s.PrefixIterator([]byte("dog"))
+	for iter.Valid() {
+		// if we want to keep bytes from iteration we must copy
+		k := iter.Key()
+		copyk := make([]byte, len(k))
+		copy(copyk, k)
+		dogs = append(dogs, copyk)
+		if len(dogs) < 2 {
+			iter.Seek([]byte("dog3"))
+		} else {
+			iter.Next()
+		}
+	}
+	err = iter.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check that we found the expected dogs
+	if !reflect.DeepEqual(dogs, expectedDogs) {
+		t.Fatalf("expected dogs %v, got %v", expectedDogs, dogs)
+	}
+}
+
+func CommonTestPrefixIteratorSeek(t *testing.T, s kvstore.KVStore) {
+
+	data := []testRow{
+		{[]byte("a"), []byte("val")},
+		{[]byte("b1"), []byte("val")},
+		{[]byte("b2"), []byte("val")},
+		{[]byte("b3"), []byte("val")},
+		{[]byte("c"), []byte("val")},
+	}
+
+	err := batchWriteRows(s, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get an iterator on a central subset of the data
+	iter := s.PrefixIterator([]byte("b"))
+	defer func() {
+		err := iter.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// check that all keys have prefix
+	found := []string{}
+	for ; iter.Valid(); iter.Next() {
+		found = append(found, string(iter.Key()))
+	}
+	for _, f := range found {
+		if !strings.HasPrefix(f, "b") {
+			t.Errorf("got key '%s' that doesn't have correct prefix", f)
+		}
+	}
+	if len(found) != 3 {
+		t.Errorf("expected 3 keys with prefix, got %d", len(found))
+	}
+
+	// now try to seek before the prefix and repeat
+	found = []string{}
+	for iter.Seek([]byte("a")); iter.Valid(); iter.Next() {
+		found = append(found, string(iter.Key()))
+	}
+	for _, f := range found {
+		if !strings.HasPrefix(f, "b") {
+			t.Errorf("got key '%s' that doesn't have correct prefix", f)
+		}
+	}
+	if len(found) != 3 {
+		t.Errorf("expected 3 keys with prefix, got %d", len(found))
+	}
+
+	// now try to seek after the prefix and repeat
+	found = []string{}
+	for iter.Seek([]byte("c")); iter.Valid(); iter.Next() {
+		found = append(found, string(iter.Key()))
+	}
+	for _, f := range found {
+		if !strings.HasPrefix(f, "b") {
+			t.Errorf("got key '%s' that doesn't have correct prefix", f)
+		}
+	}
+	if len(found) != 0 {
+		t.Errorf("expected 0 keys with prefix, got %d", len(found))
+	}
+
+}
+
+func CommonTestRangeIterator(t *testing.T, s kvstore.KVStore) {
+
+	data := []testRow{
+		{[]byte("a1"), []byte("val")},
+		{[]byte("b1"), []byte("val")},
+		{[]byte("b2"), []byte("val")},
+		{[]byte("b3"), []byte("val")},
+		{[]byte("c1"), []byte("val")},
+		{[]byte("c2"), []byte("val")},
+		{[]byte("c4"), []byte("val")},
+		{[]byte("d1"), []byte("val")},
+	}
+
+	expectedAll := make([][]byte, 0)
+	expectedBToC := make([][]byte, 0)
+	expectedCToDSeek3 := make([][]byte, 0)
+	expectedCToEnd := make([][]byte, 0)
+	for _, row := range data {
+		expectedAll = append(expectedAll, row.key)
+		if bytes.HasPrefix(row.key, []byte("b")) {
+			expectedBToC = append(expectedBToC, row.key)
+		}
+		if bytes.HasPrefix(row.key, []byte("c")) && !bytes.HasSuffix(row.key, []byte("2")) {
+			expectedCToDSeek3 = append(expectedCToDSeek3, row.key)
+		}
+		if bytes.Compare(row.key, []byte("c")) > 0 {
+			expectedCToEnd = append(expectedCToEnd, row.key)
+		}
+	}
+
+	err := batchWriteRows(s, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get a range iterator (all)
+	all := make([][]byte, 0)
+	iter := s.RangeIterator(nil, nil)
+	for iter.Valid() {
+		// if we want to keep bytes from iteration we must copy
+		k := iter.Key()
+		copyk := make([]byte, len(k))
+		copy(copyk, k)
+		all = append(all, copyk)
+		iter.Next()
+	}
+	err = iter.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check that we found all
+	if !reflect.DeepEqual(all, expectedAll) {
+		t.Fatalf("expected all %v, got %v", expectedAll, all)
+	}
+
+	// get range iterator from b - c
+	bToC := make([][]byte, 0)
+	iter = s.RangeIterator([]byte("b"), []byte("c"))
+	for iter.Valid() {
+		// if we want to keep bytes from iteration we must copy
+		k := iter.Key()
+		copyk := make([]byte, len(k))
+		copy(copyk, k)
+		bToC = append(bToC, copyk)
+		iter.Next()
+	}
+	err = iter.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check that we found b-c
+	if !reflect.DeepEqual(bToC, expectedBToC) {
+		t.Fatalf("expected b-c %v, got %v", expectedBToC, bToC)
+	}
+
+	// get range iterator from c - d, but seek to 'c3'
+	cToDSeek3 := make([][]byte, 0)
+	iter = s.RangeIterator([]byte("c"), []byte("d"))
+	for iter.Valid() {
+		// if we want to keep bytes from iteration we must copy
+		k := iter.Key()
+		copyk := make([]byte, len(k))
+		copy(copyk, k)
+		cToDSeek3 = append(cToDSeek3, copyk)
+		if len(cToDSeek3) < 2 {
+			iter.Seek([]byte("c3"))
+		} else {
+			iter.Next()
+		}
+	}
+	err = iter.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check that we found c-d with seek to c3
+	if !reflect.DeepEqual(cToDSeek3, expectedCToDSeek3) {
+		t.Fatalf("expected b-c %v, got %v", expectedCToDSeek3, cToDSeek3)
+	}
+
+	// get range iterator from c to the end
+	cToEnd := make([][]byte, 0)
+	iter = s.RangeIterator([]byte("c"), nil)
+	for iter.Valid() {
+		// if we want to keep bytes from iteration we must copy
+		k := iter.Key()
+		copyk := make([]byte, len(k))
+		copy(copyk, k)
+		cToEnd = append(cToEnd, copyk)
+		iter.Next()
+	}
+	err = iter.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check that we found c to end
+	if !reflect.DeepEqual(cToEnd, expectedCToEnd) {
+		t.Fatalf("expected b-c %v, got %v", expectedCToEnd, cToEnd)
+	}
+}
+
+func CommonTestRangeIteratorSeek(t *testing.T, s kvstore.KVStore) {
+
+	data := []testRow{
+		{[]byte("a1"), []byte("val")},
+		{[]byte("b1"), []byte("val")},
+		{[]byte("c1"), []byte("val")},
+		{[]byte("d1"), []byte("val")},
+		{[]byte("e1"), []byte("val")},
+	}
+
+	err := batchWriteRows(s, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get an iterator on a central subset of the data
+	start := []byte("b1")
+	end := []byte("d1")
+	iter := s.RangeIterator(start, end)
+
+	// seek before, at and after every possible key
+	targets := [][]byte{}
+	for _, row := range data {
+		prefix := string(row.key[:1])
+		targets = append(targets, []byte(prefix+"0"))
+		targets = append(targets, []byte(prefix+"1"))
+		targets = append(targets, []byte(prefix+"2"))
+	}
+	for _, target := range targets {
+		found := []string{}
+		for iter.Seek(target); iter.Valid(); iter.Next() {
+			found = append(found, string(iter.Key()))
+			if len(found) > len(data) {
+				t.Fatalf("enumerated more than data keys after seeking to %s",
+					string(target))
+			}
+		}
+		wanted := []string{}
+		for _, row := range data {
+			if bytes.Compare(row.key, start) < 0 ||
+				bytes.Compare(row.key, target) < 0 ||
+				bytes.Compare(row.key, end) >= 0 {
+				continue
+			}
+			wanted = append(wanted, string(row.key))
+		}
+		fs := strings.Join(found, ", ")
+		ws := strings.Join(wanted, ", ")
+		if fs != ws {
+			t.Fatalf("iterating from %s returned [%s] instead of [%s]",
+				string(target), fs, ws)
+		}
+	}
+
+	err = iter.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/kernel/store/store.go
+++ b/kernel/store/store.go
@@ -1,0 +1,15 @@
+package store
+
+import "github.com/tiglabs/baud/document"
+
+// 一个索引需要创建一个store,这个store是一个逻辑store,
+type Store interface {
+	// 写入一个文档
+    InsertDoc(doc *document.Document) error
+	// 根据doc ID查询一个文档
+	QueryDoc(slotID uint32, id string) (*document.Document, error)
+	MultiQueryDoc(slotID uint32, ids []string) ([]*document.Document, error)
+	// 删除一个文档
+	DeleteDoc(slotID uint32, id string) error
+	Close()
+}

--- a/util/hack.go
+++ b/util/hack.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// SliceToString slice to string with out data copy
+func SliceToString(b []byte) (s string) {
+	pbytes := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	pstring := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	pstring.Data = pbytes.Data
+	pstring.Len = pbytes.Len
+	return
+}
+
+// StringToSlice string to slice with out data copy
+func StringToSlice(s string) (b []byte) {
+	pbytes := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	pstring := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	pbytes.Data = pstring.Data
+	pbytes.Len = pstring.Len
+	pbytes.Cap = pstring.Len
+	return
+}


### PR DESCRIPTION
完成document的读写开发.
document直接存储到boltdb, 其中key的编码格式 type(固定一个字节)+slotID(固定四个字节)+docID,type用于区分不同的存储数据类型,slotID一方面用于partition server将来的自解释,另一方面方便将来迁移指定slot的文档数据.
另外在一级目录下增加了一个document包,负责document的相关定义和操作